### PR TITLE
Add Session Pooling for Private APIs, auth through Twitch

### DIFF
--- a/API Server/Postman Collections/MtheBot_ Contact API.postman_collection.json
+++ b/API Server/Postman Collections/MtheBot_ Contact API.postman_collection.json
@@ -1,0 +1,37 @@
+{
+	"info": {
+		"_postman_id": "423a2935-5f5d-4319-8237-5f38517a07c7",
+		"name": "MtheBot_ Contact API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "POST",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"name\": \"Bot User\",\n\t\"email\": \"user@example.com\",\n\t\"type\": \"General\",\n\t\"subject\": \"Just a comment\",\n\t\"message\": \"I love your bot!\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "localhost:8080/contact",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"contact"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/API Server/apiserver.js
+++ b/API Server/apiserver.js
@@ -11,6 +11,7 @@ const timers = require('./privateAPIs/timers');
 const events = require('./privateAPIs/events');
 const chats = require('./privateAPIs/chats');
 const init = require('./privateAPIs/init');
+const contact = require('./privateAPIs/contact');
 
 module.exports = function(db, actions) {
     // API routes
@@ -24,6 +25,7 @@ module.exports = function(db, actions) {
             'events': events,
             'chats': chats,
             'init': init,
+            'contact': contact,
         }
     }
 

--- a/API Server/apiserver.js
+++ b/API Server/apiserver.js
@@ -4,6 +4,7 @@
 // https://opensource.org/licenses/MIT
 
 const http = require('http');
+const https = require('https');
 const url = require('url');
 const users = require('./publicAPIs/users');
 const commands = require('./privateAPIs/commands');
@@ -13,11 +14,14 @@ const chats = require('./privateAPIs/chats');
 const init = require('./privateAPIs/init');
 const contact = require('./privateAPIs/contact');
 
+const getChannelFromURL = require('./utils').getChannelFromURL;
+
 module.exports = function(db, actions) {
     // API routes
     const apiRoutes = {
         public: {
             'users': users,
+            'contact': contact,
         },
         private: {
             'commands': commands,
@@ -25,15 +29,16 @@ module.exports = function(db, actions) {
             'events': events,
             'chats': chats,
             'init': init,
-            'contact': contact,
         }
     }
+
+    let sessionPool = {};
 
     // request handler
     const apiRequestHandler = (req, res) => {
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 
         // prevent CORS issue
         if (req.method === 'OPTIONS') {
@@ -41,27 +46,67 @@ module.exports = function(db, actions) {
             res.end();
             return;
         }
-
-        const originHeaderIPs = req.headers['x-forwarded-for'] ? req.headers['x-forwarded-for'].split(', ') : null;
-        const origin = originHeaderIPs ? originHeaderIPs[originHeaderIPs.length - 2] : null;
         const path = url.parse(req.url).pathname.split('/')[1];
-        //console.log(`** API REQUEST from origin ${origin}`);
-
-        const allowedOrigins = process.env.ALLOWED_ORIGINS.split(',');
         const isPrivateRequest = Object.keys(apiRoutes.private).includes(path);
-
-        if (isPrivateRequest && origin !== null && !allowedOrigins.includes(origin)) {
-            res.writeHead(401);
-            res.end('Unauthorized request to private API');
-            return;
-        }
-        
         const handler = isPrivateRequest ? apiRoutes.private[path] : apiRoutes.public[path];
-        if (handler) {
-            isPrivateRequest ? handler(db, actions, req, res) : handler(db, req, res);
+
+        if (isPrivateRequest) {
+            const channel = getChannelFromURL(req.url);
+            if (sessionPool[channel]) {
+                clearTimeout(sessionPool[channel].timeout);
+                sessionPool[channel] = {
+                    timeout: setTimeout(_ => {
+                        clearTimeout(sessionPool[channel].timeout);
+                        delete sessionPool[channel];
+                    }, 300000),
+                }
+                if (handler) {
+                    handler(db, actions, req, res);
+                } else {
+                    res.writeHead(404);
+                    res.end('Not Found');
+                }
+            } else {
+                const headers = {
+                    'Authorization': req.headers.authorization,
+                    'Client-ID': process.env.CLIENT_ID,
+                }
+                https.get('https://api.twitch.tv/helix/users', {headers: headers}, r => {
+                    let body = [];
+                    r.on('error', err => {
+                        res.writeHead(500);
+                        res.end(`ERROR: ${err}`);
+                    }).on('data', chunk => {
+                        body.push(chunk);
+                    }).on('end', _ => {
+                        body = JSON.parse(Buffer.concat(body).toString());
+                        if (body.data[0].login !== channel) {
+                            res.writeHead(401);
+                            res.end('Unauthorized request to private API');
+                        } else {
+                            sessionPool[channel] = {
+                                timeout: setTimeout(_ => {
+                                    clearTimeout(sessionPool[channel].timeout);
+                                    delete sessionPool[channel];
+                                }, 300000),
+                            }
+                            if (handler) {
+                                handler(db, actions, req, res);
+                            } else {
+                                res.writeHead(404);
+                                res.end('Not Found');
+                            }
+                        }
+                    });
+                });
+            }
         } else {
-            res.writeHead(404);
-            res.end('Not Found');
+            if (handler) {
+                handler(db, req, res);
+            } else {
+                res.writeHead(404);
+                res.end('Not Found');
+            }
         }
     }
 

--- a/API Server/privateAPIs/contact.js
+++ b/API Server/privateAPIs/contact.js
@@ -1,0 +1,52 @@
+const nodemailer = require('nodemailer');
+
+const post = (req, res) => {
+    let body = [];
+    req.on('error', err => {
+        res.writeHead(500);
+        res.end(`ERROR: ${err}`);
+    }).on('data', chunk => {
+        body.push(chunk);
+    }).on('end', _ => {
+        body = JSON.parse(Buffer.concat(body).toString());
+        const emailData = {
+            from: '', //this is ignored by gmail
+            to: process.env.GMAIL_USERNAME,
+            subject: `${body.type}: ${body.subject} from ${body.name}`,
+            html: `
+                <p>${body.name}: <a href="mailto:${body.email}?subject=RE: ${body.type}: ${body.subject}&body=\n\nYou said:\n> ${body.message}">${body.email}</a></p></br>
+                <p>${body.message}</p>
+            `,
+        }
+
+        const transport = nodemailer.createTransport({
+            host: 'smtp.gmail.com',
+            port: 465,
+            secure: true,
+            auth: {
+                user: process.env.GMAIL_USERNAME,
+                pass: process.env.GMAIL_PASSWORD
+            },
+        });
+        transport.sendMail(emailData, err => {
+            if (err) {
+                res.writeHead(500);
+                res.end(`ERROR: ${err}`);
+                return;
+            }
+            res.writeHead(200);
+            res.end("contact sent sucessfully");
+        });
+    });
+}
+
+module.exports = (db, actions, req, res) => {
+    switch (req.method) {
+        case 'POST':
+            post(req, res);
+            break;
+        default:
+            res.writeHead(400);
+            res.end('Bad Request');
+    }
+}

--- a/API Server/privateAPIs/contact.js
+++ b/API Server/privateAPIs/contact.js
@@ -40,7 +40,7 @@ const post = (req, res) => {
     });
 }
 
-module.exports = (db, actions, req, res) => {
+module.exports = (db, req, res) => {
     switch (req.method) {
         case 'POST':
             post(req, res);

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,11 @@
         "sqlstring": "2.3.1"
       }
     },
+    "nodemailer": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.6.tgz",
+      "integrity": "sha512-/kJ+FYVEm2HuUlw87hjSqTss+GU35D4giOpdSfGp7DO+5h6RlJj7R94YaYHOkoxu1CSaM0d3WRBtCzwXrY6MKA=="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "mysql": "^2.18.1",
+    "nodemailer": "^6.4.6",
     "tmi.js": "^1.5.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
# Changes
- Require Auth header from API request to private APIs
  - Should include Bearer token received from Twitch auth

# Additions
- Session pooling
  - due to change above, auth requires call to Twitch API to verify identity of callee in private API requests
  - keeps performance good by pooling sessions and requiring re-verification after 5 minutes of inactivity
- Contact API
  - Users may send a request to this API to send an email to the Bot host
  - Utilizes gmail credentials with nodemailer

# Removals
- origin checks, as they were not the right way to verify access to private API