### PR TITLE
#52: Update getSubCount to Reflect New API param

### DIFF
--- a/External Data APIs/twitch.js
+++ b/External Data APIs/twitch.js
@@ -144,20 +144,11 @@ module.exports = {
     getSubCount: channelID => {
         return new Promise((resolve, reject) => {
             getTokenForChannel(channelID).then(token => {
-                let total = 0;
-                const getCountForPage = (page, callback) => {
-                    httpsRequest(`https://api.twitch.tv/helix/subscriptions?broadcaster_id=${channelID}${page ? `&after=${page}` : ''}`, {headers: createHeaderObject(token), method: 'GET'}).then(data => {
-                        total += data.data.length;
-                        if (data.data.length < 100) {
-                            callback();
-                        } else {
-                            getCountForPage(data.pagination.cursor, callback);
-                        }
-                    }).catch(err => {
-                        reject(err);
-                    });
-                }
-                getCountForPage(null, _ => {resolve(total - 1)}); //subtract 1 because it counts broadcaster as 1
+                httpsRequest(`https://api.twitch.tv/helix/subscriptions?broadcaster_id=${channelID}`, {headers: createHeaderObject(token), method: 'GET'}).then(data => {
+                    resolve(data.total);
+                }).catch(err => {
+                    reject(err);
+                });
             }).catch(err => {
                 reject(err);
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "mthebot",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mthebot",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Chatbot for Twitch",
   "main": "app.js",
   "dependencies": {


### PR DESCRIPTION
Updates the `getSubCount` function in Twitch API datatags to reflect the new `total` param returned by the API.  This should increase efficiency for users who have a large amount of subs, as before the calculation would have to make multiple calls to the API for those with more than 100 subscribers