### PR TITLE
#57: remainder of async/await, some bug fixes

### DIFF
--- a/DataTags/Twitch/twitchDataTags.js
+++ b/DataTags/Twitch/twitchDataTags.js
@@ -25,7 +25,7 @@ module.exports = [
                     `;
                     return val;
                 } else {
-                    return `${userstate["user-id"]} does not follow ${channel}`;
+                    return `${userstate["username"]} does not follow ${channel}`;
                 }
             } catch {
                 return "error fetching followage data";
@@ -82,8 +82,7 @@ module.exports = [
             try {
                 const data = await twitchAPI.getStreamData(channel);
                 if (data) {
-                    const name = await twitchAPI.getGameName(data.game_id);
-                    return name;
+                    return data.game_name;
                 } else {
                     return `${channel} is not live`;
                 }

--- a/app.js
+++ b/app.js
@@ -91,8 +91,12 @@ const onChat = async (channelKey, userstate, message, self) => {
                     );
                 for (const { tag, dataFetch } of DATA_TAGS) {
                     if (message.includes(tag)) {
-                        const value = await dataFetch(channelName, userstate);
-                        message = message.replace(new RegExp(tag, "g"), value);
+                        try {
+                            const value = await dataFetch(channelName, userstate);
+                            message = message.replace(new RegExp(tag, "g"), value);
+                        } catch (err) {
+                            message = message.replace(new RegExp(tag, "g"), err.message);
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Changes
- Switch to async/await in Twitch external data API functions
  - closes #57 
  - much cleaner code, and substantial line count reduction, yay!
- Changed `{{game}}` data tag logic
  - now uses `game_name` from `getStreams`, as that is [now supported](https://dev.twitch.tv/docs/api/reference/#get-streams) (well, it has been, but I never got around to fixing it)
  - allows removal of `getGameName` Twitch API function
## Fixes
- `user-id` -> `username` in `{{followage}}` datatag "not following" message
- datatag error handling now displays error message in chat rather than not chatting at all