### PR TITLE
General DBService Improvements

### DIFF
--- a/dbservice.js
+++ b/dbservice.js
@@ -6,372 +6,206 @@
 const mysql = require("mysql2");
 const defaultEvents = require("./defaultEvents.json");
 
+const { RDS_HOSTNAME, RDS_USERNAME, RDS_PASSWORD, RDS_PORT, RDS_DB_NAME, CLIENT_SECRET } = process.env;
+
 class DBService {
     constructor() {
         if (!DBService._instance) {
             DBService._instance = this;
         }
 
-        const { RDS_HOSTNAME, RDS_USERNAME, RDS_PASSWORD, RDS_PORT, RDS_DB_NAME } = process.env;
-
-        this.db = mysql.createPool({
-            host: RDS_HOSTNAME,
-            user: RDS_USERNAME,
-            password: RDS_PASSWORD,
-            port: RDS_PORT,
-            database: RDS_DB_NAME,
-        });
+        this.db = mysql
+            .createPool({
+                host: RDS_HOSTNAME,
+                user: RDS_USERNAME,
+                password: RDS_PASSWORD,
+                port: RDS_PORT,
+                database: RDS_DB_NAME,
+            })
+            .promise();
 
         return DBService._instance;
     }
 
-    getUserCount() {
-        return new Promise((resolve, reject) => {
-            this.db.query("SELECT COUNT(*) AS users FROM channels WHERE enabled=1", (err, results) => {
-                if (err) reject(err);
-                else resolve(results[0].users);
-            });
-        });
+    async getUserCount() {
+        const [results] = await this.db.query("SELECT COUNT(*) AS users FROM channels WHERE enabled=1");
+        return results[0].users;
     }
 
-    getEnabledChannels() {
-        return new Promise((resolve, reject) => {
-            this.db.query("SELECT id FROM channels WHERE enabled=1", (err, results) => {
-                if (err) reject(err);
-                else resolve(results.map((r) => r.id));
-            });
-        });
+    async getEnabledChannels() {
+        const [results] = await this.db.query("SELECT id FROM channels WHERE enabled=1");
+        return results.map(({ id }) => id);
     }
 
-    initChannel(id, name, authToken, refreshToken) {
-        return new Promise((resolve, reject) => {
-            let query = `INSERT INTO channels (id, name, token, refresh_token, enabled) VALUES (${id}, "${name}", AES_ENCRYPT("${authToken}", "${process.env.CLIENT_SECRET}"), AES_ENCRYPT("${refreshToken}", "${process.env.CLIENT_SECRET}"), false);`;
-            let eventsQuery = `INSERT INTO events (channel_id, name, message, enabled) VALUES`;
-            Object.keys(defaultEvents).forEach((k, i) => {
-                eventsQuery = `${eventsQuery} (${id}, "${k}", "${defaultEvents[k].message}", ${
-                    defaultEvents[k].enabled
-                })${i === Object.keys(defaultEvents).length - 1 ? ";" : ","}`;
-            });
-            this.db.query(query, (err) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    this.db.query(eventsQuery, (e) => {
-                        if (e) {
-                            reject(e);
-                        } else {
-                            resolve(true);
-                        }
-                    });
-                }
-            });
+    async initChannel(id, name, authToken, refreshToken) {
+        let query = `INSERT INTO channels (id, name, token, refresh_token, enabled) VALUES (${id}, "${name}", AES_ENCRYPT("${authToken}", "${CLIENT_SECRET}"), AES_ENCRYPT("${refreshToken}", "${CLIENT_SECRET}"), false);`;
+        let eventsQuery = `INSERT INTO events (channel_id, name, message, enabled) VALUES`;
+        Object.entries(defaultEvents).forEach(([k, v], i, arr) => {
+            eventsQuery = `${eventsQuery} (${id}, "${k}", "${v.message}", ${v.enabled})${
+                i === arr.length - 1 ? ";" : ","
+            }`;
         });
+        await this.db.query(query);
+        await this.db.query(eventsQuery);
     }
 
-    updateTokensForChannel(id, accessToken, refreshToken) {
-        return new Promise((resolve, reject) => {
-            this.db.query(
-                `UPDATE channels SET token=AES_ENCRYPT(?, '${process.env.CLIENT_SECRET}'), refresh_token=AES_ENCRYPT(?, '${process.env.CLIENT_SECRET}') WHERE id=?`,
-                [accessToken, refreshToken, id],
-                (err) => {
-                    if (err) reject(err);
-                    else resolve(true);
-                }
+    async updateTokensForChannel(id, accessToken, refreshToken) {
+        await this.db.query(
+            `UPDATE channels SET token=AES_ENCRYPT(?, '${CLIENT_SECRET}'), refresh_token=AES_ENCRYPT(?, '${CLIENT_SECRET}') WHERE id=?`,
+            [accessToken, refreshToken, id]
+        );
+    }
+
+    async getTokensForChannel(id) {
+        const [results] = await this.db.query(
+            `SELECT AES_DECRYPT(token, '${CLIENT_SECRET}') as access_token, AES_DECRYPT(refresh_token, '${CLIENT_SECRET}') as refresh_token FROM channels WHERE id=?`,
+            [id]
+        );
+        return results[0];
+    }
+
+    async getChannel(id) {
+        const [results] = await this.db.query("SELECT * FROM channels WHERE id=?", [id]);
+        if (results.length) {
+            return results[0];
+        }
+    }
+
+    async updateNameForChannel(name, id) {
+        await this.db.query(`UPDATE channels SET name=? WHERE id=?`, [name, id]);
+    }
+
+    async enableChannel(id) {
+        await this.db.query(`UPDATE channels SET enabled=true WHERE id=?`, [id]);
+    }
+
+    async disableChannel(id) {
+        await this.db.query(`UPDATE channels SET enabled=false WHERE id=?`, [id]);
+    }
+
+    async getAllCommandsForChannel(id) {
+        const [results] = await this.db.query(
+            `SELECT alias,message,cooldown,user_level FROM commands WHERE channel_id=?`,
+            [id]
+        );
+        return results;
+    }
+
+    async getCommandForChannel(alias, id) {
+        const [results] = await this.db.query(
+            `SELECT alias,message,cooldown,user_level FROM commands WHERE channel_id=? and alias=?`,
+            [id, alias]
+        );
+        if (results.length) {
+            return results[0];
+        }
+    }
+
+    async addCommandForChannel(data, id) {
+        const existing = await this.getCommandForChannel(data.alias, id);
+        if (!existing) {
+            await this.db.query(
+                `INSERT INTO commands (channel_id, alias, message, cooldown, user_level) VALUES (?, ?, ?, ?, ?)`,
+                [id, data.alias, data.message, data.cooldown, data.user_level]
             );
+            return data;
+        }
+    }
+
+    async updateCommandForChannel(alias, data, id) {
+        const [result] = await this.db.query(
+            `UPDATE commands SET alias=?, message=?, cooldown=?, user_level=? where channel_id=? and alias=?`,
+            [data.alias, data.message, data.cooldown, data.user_level, id, alias]
+        );
+        if (result.affectedRows > 0) {
+            return data;
+        }
+    }
+
+    async deleteCommandForChannel(alias, id) {
+        const [result] = await this.db.query(`DELETE FROM commands where channel_id=? and alias=?`, [id, alias]);
+        if (result.affectedRows > 0) {
+            return true;
+        }
+    }
+
+    async getAllEventsForChannel(id) {
+        const [results] = await this.db.query(`SELECT name,message,enabled FROM events WHERE channel_id=?`, [id]);
+        return results.map((event) => {
+            return { ...event, enabled: Boolean(event.enabled) };
         });
     }
 
-    getTokensForChannel(id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(
-                `SELECT AES_DECRYPT(token, '${process.env.CLIENT_SECRET}') as access_token, AES_DECRYPT(refresh_token, '${process.env.CLIENT_SECRET}') as refresh_token FROM channels WHERE id=?`,
-                [id],
-                (err, results) => {
-                    if (err) reject(err);
-                    else {
-                        const data = {
-                            access_token: results[0].access_token.toString(),
-                            refresh_token: results[0].refresh_token.toString(),
-                        };
-                        resolve(data);
-                    }
-                }
+    async getEventForChannel(name, id) {
+        const [results] = await this.db.query(`SELECT name,message,enabled FROM events WHERE channel_id=? and name=?`, [
+            id,
+            name,
+        ]);
+        if (results.length) {
+            const { name, message, enabled } = results[0];
+            return { name, message, enabled: Boolean(enabled) };
+        }
+    }
+
+    async updateEventForChannel(name, data, id) {
+        const [result] = await this.db.query(
+            `UPDATE events SET name=?, message=?, enabled=? where channel_id=? and name=?`,
+            [name, data.message, data.enabled, id, name]
+        );
+        if (result.affectedRows > 0) {
+            return { name, ...data };
+        }
+    }
+
+    async getAllTimersForChannel(id) {
+        const [results] = await this.db.query(
+            `SELECT name,message,enabled,\`interval\`,message_threshold FROM timers WHERE channel_id=?`,
+            [id]
+        );
+        return results.map((timer) => {
+            return { ...timer, enabled: Boolean(timer.enabled) };
+        });
+    }
+
+    async getTimerForChannel(name, id) {
+        const [results] = await this.db.query(
+            `SELECT name,message,enabled,\`interval\`,message_threshold FROM timers WHERE channel_id=? and name=?`,
+            [id, name]
+        );
+        if (results.length) {
+            const timer = results[0];
+            return { ...timer, enabled: Boolean(timer.enabled) };
+        }
+    }
+
+    async addTimerForChannel(data, id) {
+        const { name, enabled, message, interval, message_threshold } = data;
+        const existing = await this.getTimerForChannel(name, id);
+        if (!existing) {
+            await this.db.query(
+                `INSERT INTO timers (channel_id, name, enabled, message, \`interval\`, message_threshold) VALUES (?, ?, ?, ?, ?, ?)`,
+                [id, name, enabled, message, interval, message_threshold]
             );
-        });
+            return data;
+        }
     }
 
-    getChannel(id) {
-        return new Promise((resolve, reject) => {
-            this.db.query("SELECT * FROM channels WHERE id=?", [id], (err, results) => {
-                if (err) {
-                    reject(err);
-                } else if (!results.length) {
-                    resolve(undefined);
-                }
-                resolve(results[0]);
-            });
-        });
+    async updateTimerForChannel(name, data, id) {
+        const { name: newName, enabled, message, interval, message_threshold } = data;
+        const [result] = await this.db.query(
+            `UPDATE timers SET name=?, enabled=?, message=?, \`interval\`=?, message_threshold=? where channel_id=? and name=?`,
+            [newName, enabled, message, interval, message_threshold, id, name]
+        );
+        if (result.affectedRows > 0) {
+            return data;
+        }
     }
 
-    updateNameForChannel(name, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`UPDATE channels SET name=? WHERE id=?`, [name, id], (err) => {
-                if (err) {
-                    reject(err);
-                }
-                resolve();
-            });
-        });
-    }
-
-    enableChannel(id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`UPDATE channels SET enabled=true WHERE id=?`, [id], (err) => {
-                if (err) {
-                    reject(err);
-                }
-                resolve();
-            });
-        });
-    }
-
-    disableChannel(id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`UPDATE channels SET enabled=false WHERE id=?`, [id], (err) => {
-                if (err) {
-                    reject(err);
-                }
-                resolve();
-            });
-        });
-    }
-
-    getAllCommandsForChannel(id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`SELECT * FROM commands WHERE channel_id=?`, [id], (err, results) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    const data = results.map((c) => {
-                        return {
-                            alias: c.alias,
-                            message: c.message,
-                            cooldown: c.cooldown,
-                            user_level: c.user_level,
-                        };
-                    });
-                    resolve(data);
-                }
-            });
-        });
-    }
-
-    getCommandForChannel(alias, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`SELECT * FROM commands WHERE channel_id=? and alias=?`, [id, alias], (err, results) => {
-                if (err) {
-                    reject(err);
-                } else if (!results.length) {
-                    resolve(undefined);
-                } else {
-                    const data = {
-                        alias: results[0].alias,
-                        message: results[0].message,
-                        cooldown: results[0].cooldown,
-                        user_level: results[0].user_level,
-                    };
-                    resolve(data);
-                }
-            });
-        });
-    }
-
-    addCommandForChannel(data, id) {
-        return new Promise((resolve, reject) => {
-            this.getCommandForChannel(data.alias, id)
-                .then((results) => {
-                    if (results) {
-                        resolve(undefined);
-                    } else {
-                        this.db.query(
-                            `INSERT INTO commands (channel_id, alias, message, cooldown, user_level) VALUES (?, ?, ?, ?, ?)`,
-                            [id, data.alias, data.message, data.cooldown, data.user_level],
-                            (err) => {
-                                if (err) reject(err);
-                                else resolve(data);
-                            }
-                        );
-                    }
-                })
-                .catch((err) => {
-                    reject(err);
-                });
-        });
-    }
-
-    updateCommandForChannel(alias, data, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(
-                `UPDATE commands SET alias=?, message=?, cooldown=?, user_level=? where channel_id=? and alias=?`,
-                [data.alias, data.message, data.cooldown, data.user_level, id, alias],
-                (err, results) => {
-                    if (err) reject(err);
-                    else if (!results.affectedRows) resolve(undefined);
-                    else resolve(data);
-                }
-            );
-        });
-    }
-
-    deleteCommandForChannel(alias, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`DELETE FROM commands where channel_id=? and alias=?`, [id, alias], (err, results) => {
-                if (err) reject(err);
-                else if (!results.affectedRows) resolve(undefined);
-                else resolve(true);
-            });
-        });
-    }
-
-    getAllEventsForChannel(id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`SELECT * FROM events WHERE channel_id=?`, [id], (err, results) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    const data = results.map((c) => {
-                        return {
-                            name: c.name,
-                            message: c.message,
-                            enabled: c.enabled ? true : false,
-                        };
-                    });
-                    resolve(data);
-                }
-            });
-        });
-    }
-
-    getEventForChannel(name, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`SELECT * FROM events WHERE channel_id=? and name=?`, [id, name], (err, results) => {
-                if (err) {
-                    reject(err);
-                } else if (!results.length) {
-                    resolve(undefined);
-                } else {
-                    const data = {
-                        name: results[0].name,
-                        message: results[0].message,
-                        enabled: results[0].enabled ? true : false,
-                    };
-                    resolve(data);
-                }
-            });
-        });
-    }
-
-    updateEventForChannel(name, data, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(
-                `UPDATE events SET name=?, message=?, enabled=? where channel_id=? and name=?`,
-                [name, data.message, data.enabled, id, name],
-                (err, results) => {
-                    if (err) reject(err);
-                    else if (!results.affectedRows) resolve(undefined);
-                    else resolve(data);
-                }
-            );
-        });
-    }
-
-    getAllTimersForChannel(id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`SELECT * FROM timers WHERE channel_id=?`, [id], (err, results) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    const data = results.map((c) => {
-                        return {
-                            name: c.name,
-                            message: c.message,
-                            enabled: c.enabled ? true : false,
-                            interval: c.interval,
-                            message_threshold: c.message_threshold,
-                        };
-                    });
-                    resolve(data);
-                }
-            });
-        });
-    }
-
-    getTimerForChannel(name, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`SELECT * FROM timers WHERE channel_id=? and name=?`, [id, name], (err, results) => {
-                if (err) {
-                    reject(err);
-                } else if (!results.length) {
-                    resolve(undefined);
-                } else {
-                    const data = {
-                        name: results[0].name,
-                        message: results[0].message,
-                        enabled: results[0].enabled ? true : false,
-                        interval: results[0].interval,
-                        message_threshold: results[0].message_threshold,
-                    };
-                    resolve(data);
-                }
-            });
-        });
-    }
-
-    addTimerForChannel(data, id) {
-        return new Promise((resolve, reject) => {
-            this.getTimerForChannel(data.name, id)
-                .then((results) => {
-                    if (results) {
-                        resolve(undefined);
-                    } else {
-                        this.db.query(
-                            `INSERT INTO timers (channel_id, name, enabled, message, \`interval\`, message_threshold) VALUES (?, ?, ?, ?, ?, ?)`,
-                            [id, data.name, data.enabled, data.message, data.interval, data.message_threshold],
-                            (err) => {
-                                if (err) reject(err);
-                                else resolve(data);
-                            }
-                        );
-                    }
-                })
-                .catch((err) => {
-                    reject(err);
-                });
-        });
-    }
-
-    updateTimerForChannel(name, data, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(
-                `UPDATE timers SET name=?, enabled=?, message=?, \`interval\`=?, message_threshold=? where channel_id=? and name=?`,
-                [data.name, data.enabled, data.message, data.interval, data.message_threshold, id, name],
-                (err, results) => {
-                    if (err) reject(err);
-                    else if (!results.affectedRows) resolve(undefined);
-                    else resolve(data);
-                }
-            );
-        });
-    }
-
-    deleteTimerForChannel(name, id) {
-        return new Promise((resolve, reject) => {
-            this.db.query(`DELETE FROM timers where channel_id=? and name=?`, [id, name], (err, results) => {
-                if (err) reject(err);
-                else if (!results.affectedRows) resolve(undefined);
-                else resolve(true);
-            });
-        });
+    async deleteTimerForChannel(name, id) {
+        const [result] = await this.db.query(`DELETE FROM timers where channel_id=? and name=?`, [id, name]);
+        if (result.affectedRows > 0) {
+            return true;
+        }
     }
 }
 

--- a/dbservice.js
+++ b/dbservice.js
@@ -38,10 +38,9 @@ class DBService {
     }
 
     async initChannel(id, name, authToken, refreshToken) {
-        const placeholders = new Array(Object.keys(defaultEvents).length).fill("(?, ?, ?, ?)").join(",");
-        const values = Object.entries(defaultEvents)
-            .map(([k, v]) => [id, k, v.message, v.enabled])
-            .flat();
+        const entries = Object.entries(defaultEvents);
+        const placeholders = new Array(entries.length).fill("(?, ?, ?, ?)").join(",");
+        const values = entries.map(([event, { message, enabled }]) => [id, event, message, enabled]).flat();
 
         await this.db.execute(
             "INSERT INTO channels (id, name, token, refresh_token, enabled) VALUES (?, ?, AES_ENCRYPT(?, ?), AES_ENCRYPT(?, ?), false)",

--- a/defaultEvents.json
+++ b/defaultEvents.json
@@ -1,7 +1,7 @@
 {
     "follow": {
         "enabled": true,
-        "message": "{{username}} followed!"
+        "message": "{{user}} followed!"
     },
     "sub": {
         "enabled": true,

--- a/utils.js
+++ b/utils.js
@@ -68,6 +68,6 @@ module.exports = {
             : 0;
     },
     timedLog: (message) => {
-        console.log(`${new Date(Date.now()).toUTCString()} ${message}`);
+        console.log(`${new Date().toUTCString()} ${message}`);
     },
 };


### PR DESCRIPTION
## Changes
- Switched to using `mysql2` promises in DBService
  - closes #77 
- Switch to using prepared statements in DBService
  - should further improve SQL injection prevention
  - sidenote: I am unusually proud of my solution to this in `initChannel`
  - closes #85 

## Fixes
- Fixed incorrect datatag in default `follow` event from `{{username}}` to `{{user}}`
  - closes #88 
- Removed redundancy in `timedLog` util