### PR TITLE
Request Improvements, Auto Add as Moderator on Enable

### DIFF
--- a/API Server/apiserver.js
+++ b/API Server/apiserver.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Mitchell Adair
+// Copyright (c) 2020-2022 Mitchell Adair
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -164,7 +164,7 @@ module.exports = function (actions) {
     server.route("/users").get(users.get);
 
     server.listen(port, () => {
-        timedLog(`** BOT: API Server listening on port ${port}`);
+        timedLog(`API Server listening on port ${port}`);
     });
     return server;
 };

--- a/API Server/privateAPIs/chats.js
+++ b/API Server/privateAPIs/chats.js
@@ -1,9 +1,10 @@
-// Copyright (c) 2020 Mitchell Adair
+// Copyright (c) 2020-2022 Mitchell Adair
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
 const DBService = require("../../dbservice");
+const { setModeratorStatus } = require("../../External Data APIs/twitch");
 
 const get = async (req, res) => {
     const { channel } = req.params;
@@ -24,6 +25,7 @@ const post = async (actions, req, res) => {
     try {
         await DBService.enableChannel(channel);
         await actions.joinChannel(channel);
+        await setModeratorStatus(channel, true);
         res.status(200).send(`Bot set to enabled for channel ${channel}`);
     } catch (err) {
         res.status(500).send(err.message);
@@ -35,6 +37,7 @@ const remove = async (actions, req, res) => {
     try {
         await DBService.disableChannel(channel);
         await actions.leaveChannel(channel);
+        await setModeratorStatus(channel, false);
         res.status(200).send(`Bot set to disabled for channel ${channel}`);
     } catch (err) {
         res.status(500).send(err.message);

--- a/API Server/publicAPIs/auth.js
+++ b/API Server/publicAPIs/auth.js
@@ -3,7 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-const { httpsRequest } = require("../../utils");
+const { request } = require("../../utils");
 const DBService = require("../../dbservice");
 const crypto = require("crypto");
 
@@ -28,7 +28,7 @@ const post = async (actions, sessionPool, req, res) => {
 
     if (code) {
         try {
-            const { access_token, refresh_token, expires_in } = await httpsRequest(
+            const { access_token, refresh_token, expires_in } = await request(
                 `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&code=${code}&grant_type=authorization_code&redirect_uri=${AUTH_REDIRECT_URL}`,
                 { method: "POST" }
             );
@@ -38,7 +38,7 @@ const post = async (actions, sessionPool, req, res) => {
             };
             const {
                 data: [user],
-            } = await httpsRequest(`https://api.twitch.tv/helix/users`, { headers, method: "GET" });
+            } = await request(`https://api.twitch.tv/helix/users`, { headers, method: "GET" });
             const data = await DBService.getChannel(user.id);
             if (data) {
                 await DBService.updateTokensForChannel(user.id, access_token, refresh_token);

--- a/API Server/publicAPIs/auth.js
+++ b/API Server/publicAPIs/auth.js
@@ -38,10 +38,9 @@ const post = async (actions, sessionPool, req, res) => {
                 "client-id": CLIENT_ID,
                 authorization: `Bearer ${access_token}`,
             };
-            const userResponse = await request(`https://api.twitch.tv/helix/users`, { headers });
             const {
                 data: [user],
-            } = await userResponse.json();
+            } = await request(`https://api.twitch.tv/helix/users`, { headers });
             const data = await DBService.getChannel(user.id);
             if (data) {
                 await DBService.updateTokensForChannel(user.id, access_token, refresh_token);

--- a/API Server/publicAPIs/auth.js
+++ b/API Server/publicAPIs/auth.js
@@ -3,6 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+const { request } = require("../../utils");
 const fetch = require("node-fetch");
 const DBService = require("../../dbservice");
 const crypto = require("crypto");
@@ -37,7 +38,7 @@ const post = async (actions, sessionPool, req, res) => {
                 "client-id": CLIENT_ID,
                 authorization: `Bearer ${access_token}`,
             };
-            const userResponse = await fetch(`https://api.twitch.tv/helix/users`, { headers, method: "GET" });
+            const userResponse = await request(`https://api.twitch.tv/helix/users`, { headers });
             const {
                 data: [user],
             } = await userResponse.json();

--- a/API Server/publicAPIs/auth.js
+++ b/API Server/publicAPIs/auth.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Mitchell Adair
+// Copyright (c) 2020-2022 Mitchell Adair
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/ChannelManager/channelManager.js
+++ b/ChannelManager/channelManager.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Mitchell Adair
+// Copyright (c) 2020-2022 Mitchell Adair
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -41,7 +41,7 @@ class ChannelManager {
         if (channel) {
             channel.clearTimers();
             delete this.channels[channelKey];
-            timedLog(`** BOT: Removed channel ${channelKey} from active channels`);
+            timedLog(`Removed channel ${channelKey} from active channels`);
         }
     }
 
@@ -60,7 +60,7 @@ class ChannelManager {
             this.refreshChannel(channelKey);
         } else {
             await this.fetchChannelData(channelKey);
-            timedLog(`** BOT: Added channel ${channelKey} to active channels`);
+            timedLog(`Added channel ${channelKey} to active channels`);
         }
         return this.getChannel(channelKey);
     }
@@ -73,7 +73,7 @@ class ChannelManager {
 
             if (channel.name !== channelKey) {
                 await DBService.updateNameForChannel(channelKey, channelID);
-                timedLog(`** BOT: Updated name for id ${channelID} in DB to ${channelKey}`);
+                timedLog(`Updated name for id ${channelID} in DB to ${channelKey}`);
             }
 
             const commands = await DBService.getAllCommandsForChannel(channelID);
@@ -87,7 +87,7 @@ class ChannelManager {
 
             this.addChannel(channelKey, channelID, commands, events, timers);
         } catch (error) {
-            timedLog(`** BOT: ERROR getting user data for channel ${channelKey}`);
+            timedLog(`ERROR getting user data for channel ${channelKey}`);
             throw error;
         }
     }

--- a/External Data APIs/twitch.js
+++ b/External Data APIs/twitch.js
@@ -3,7 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-const httpsRequest = require("../utils").httpsRequest;
+const { request } = require("../utils");
 const DBService = require("../dbservice");
 
 const { CLIENT_ID, CLIENT_SECRET } = process.env;
@@ -18,7 +18,7 @@ const createHeaderObject = (token) => {
 };
 
 const validateToken = async (token) => {
-    const data = await httpsRequest("https://id.twitch.tv/oauth2/validate", {
+    const data = await request("https://id.twitch.tv/oauth2/validate", {
         method: "GET",
         headers: createHeaderObject(token),
     });
@@ -35,7 +35,7 @@ const getTokenForChannel = async (id) => {
         return tokens.access_token;
     } catch (err) {
         if (err.message === "invalid access token") {
-            const { access_token, refresh_token } = await httpsRequest(
+            const { access_token, refresh_token } = await request(
                 `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=refresh_token&refresh_token=${tokens.refresh_token}`,
                 { method: "POST" }
             );
@@ -47,7 +47,7 @@ const getTokenForChannel = async (id) => {
 };
 
 const getNewToken = async () => {
-    const data = await httpsRequest(
+    const data = await request(
         `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=client_credentials`,
         { method: "POST" }
     );
@@ -72,7 +72,7 @@ module.exports = {
     getUser: async (key, isByLogin = false) => {
         const token = await getAppAccessToken();
         const query = isByLogin ? "login" : "id";
-        const data = await httpsRequest(`https://api.twitch.tv/helix/users?${query}=${key}`, {
+        const data = await request(`https://api.twitch.tv/helix/users?${query}=${key}`, {
             headers: createHeaderObject(token),
             method: "GET",
         });
@@ -87,7 +87,7 @@ module.exports = {
             chunk.forEach((id) => {
                 queryString = `${queryString}id=${id}&`;
             });
-            const { data } = await httpsRequest(`https://api.twitch.tv/helix/users?${queryString}`, {
+            const { data } = await request(`https://api.twitch.tv/helix/users?${queryString}`, {
                 headers: createHeaderObject(token),
                 method: "GET",
             });
@@ -99,7 +99,7 @@ module.exports = {
     },
     getFollowData: async (fromID, toID) => {
         const token = await getAppAccessToken();
-        const data = await httpsRequest(`https://api.twitch.tv/helix/users/follows?from_id=${fromID}&to_id=${toID}`, {
+        const data = await request(`https://api.twitch.tv/helix/users/follows?from_id=${fromID}&to_id=${toID}`, {
             headers: createHeaderObject(token),
             method: "GET",
         });
@@ -107,7 +107,7 @@ module.exports = {
     },
     getFollowCount: async (channelID) => {
         const token = await getAppAccessToken();
-        const { total } = await httpsRequest(`https://api.twitch.tv/helix/users/follows?to_id=${channelID}&first=1`, {
+        const { total } = await request(`https://api.twitch.tv/helix/users/follows?to_id=${channelID}&first=1`, {
             headers: createHeaderObject(token),
             method: "GET",
         });
@@ -115,7 +115,7 @@ module.exports = {
     },
     getSubCount: async (channelID) => {
         const token = await getTokenForChannel(channelID);
-        const { total } = await httpsRequest(`https://api.twitch.tv/helix/subscriptions?broadcaster_id=${channelID}`, {
+        const { total } = await request(`https://api.twitch.tv/helix/subscriptions?broadcaster_id=${channelID}`, {
             headers: createHeaderObject(token),
             method: "GET",
         });
@@ -123,7 +123,7 @@ module.exports = {
     },
     getStreamData: async (loginName) => {
         const token = await getAppAccessToken();
-        const data = await httpsRequest(`https://api.twitch.tv/helix/streams?user_login=${loginName}`, {
+        const data = await request(`https://api.twitch.tv/helix/streams?user_login=${loginName}`, {
             headers: createHeaderObject(token),
             method: "GET",
         });

--- a/External Data APIs/twitch.js
+++ b/External Data APIs/twitch.js
@@ -1,82 +1,96 @@
-// Copyright (c) 2020 Mitchell Adair
+// Copyright (c) 2020-2022 Mitchell Adair
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-const { request } = require("../utils");
+const { request, timedLog } = require("../utils");
+const fetch = require("node-fetch");
 const DBService = require("../dbservice");
 
 const { CLIENT_ID, CLIENT_SECRET } = process.env;
 
 let appAccessToken;
+let validationInterval;
 
 const createHeaderObject = (token) => {
     return {
         "client-id": CLIENT_ID,
-        Authorization: `Bearer ${token}`,
+        authorization: `Bearer ${token}`,
     };
 };
 
 const validateToken = async (token) => {
-    const data = await request("https://id.twitch.tv/oauth2/validate", {
-        method: "GET",
+    const res = await fetch("https://id.twitch.tv/oauth2/validate", {
         headers: createHeaderObject(token),
     });
-    if (data.status === 401 && data.message === "invalid access token") {
-        throw new Error(data.message);
+    if (res.status === 401) {
+        await getNewAppAccessToken();
+        resetValidationInterval();
     }
 };
 
 const getTokenForChannel = async (id) => {
-    let tokens;
-    try {
-        tokens = await DBService.getTokensForChannel(id);
-        await validateToken(tokens.access_token);
-        return tokens.access_token;
-    } catch (err) {
-        if (err.message === "invalid access token") {
-            const { access_token, refresh_token } = await request(
-                `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=refresh_token&refresh_token=${tokens.refresh_token}`,
-                { method: "POST" }
-            );
-            await DBService.updateTokensForChannel(id, access_token, refresh_token);
-            return access_token;
-        }
-        throw err;
-    }
+    const { access_token } = await DBService.getTokensForChannel(id);
+    return access_token;
 };
 
-const getNewToken = async () => {
-    const data = await request(
+const getNewUserAuthToken = async (id) => {
+    const { refresh_token: rt } = await DBService.getTokensForChannel(id);
+    const res = await fetch(
+        `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=refresh_token&refresh_token=${rt}`,
+        { method: "POST" }
+    );
+    const { access_token, refresh_token } = res.json();
+    await DBService.updateTokensForChannel(id, access_token, refresh_token);
+    return access_token;
+};
+
+const getNewAppAccessToken = async () => {
+    appAccessToken = undefined;
+    const res = await fetch(
         `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=client_credentials`,
         { method: "POST" }
     );
-    appAccessToken = data.access_token;
+    const { access_token } = await res.json();
+    appAccessToken = access_token;
     return appAccessToken;
 };
 
-const getAppAccessToken = async () => {
-    if (appAccessToken) {
-        try {
-            await validateToken(appAccessToken);
-            return appAccessToken;
-        } catch {
-            return await getNewToken();
-        }
-    } else {
-        return await getNewToken();
-    }
+const getAppAccessToken = () => {
+    return new Promise((resolve, reject) => {
+        const start = new Date();
+        const retry = () => {
+            if (appAccessToken) {
+                resolve(appAccessToken);
+            } else if (new Date() - start > 1000000) {
+                const message = "Timed out trying to get token";
+                reject(message);
+            } else {
+                setTimeout(retry);
+            }
+        };
+        retry();
+    });
 };
+
+const resetValidationInterval = () => {
+    clearInterval(validationInterval);
+    validationInterval = setInterval(validateToken, 3600000);
+};
+
+// init the access token on start
+getNewAppAccessToken();
 
 module.exports = {
     getUser: async (key, isByLogin = false) => {
         const token = await getAppAccessToken();
         const query = isByLogin ? "login" : "id";
-        const data = await request(`https://api.twitch.tv/helix/users?${query}=${key}`, {
-            headers: createHeaderObject(token),
-            method: "GET",
-        });
-        return data.data[0];
+        const { data } = await request(
+            `https://api.twitch.tv/helix/users?${query}=${key}`,
+            { headers: createHeaderObject(token) },
+            getNewAppAccessToken
+        );
+        return data[0];
     },
     getBatchUsersByID: async (ids) => {
         const token = await getAppAccessToken();
@@ -87,10 +101,11 @@ module.exports = {
             chunk.forEach((id) => {
                 queryString = `${queryString}id=${id}&`;
             });
-            const { data } = await request(`https://api.twitch.tv/helix/users?${queryString}`, {
-                headers: createHeaderObject(token),
-                method: "GET",
-            });
+            const { data } = await request(
+                `https://api.twitch.tv/helix/users?${queryString}`,
+                { headers: createHeaderObject(token) },
+                getNewAppAccessToken
+            );
             data.forEach((user) => {
                 users.push({ id: user.id, name: user.login });
             });
@@ -99,34 +114,38 @@ module.exports = {
     },
     getFollowData: async (fromID, toID) => {
         const token = await getAppAccessToken();
-        const data = await request(`https://api.twitch.tv/helix/users/follows?from_id=${fromID}&to_id=${toID}`, {
-            headers: createHeaderObject(token),
-            method: "GET",
-        });
-        return data.data[0];
+        const { data } = await request(
+            `https://api.twitch.tv/helix/users/follows?from_id=${fromID}&to_id=${toID}`,
+            { headers: createHeaderObject(token) },
+            getNewAppAccessToken
+        );
+        return data[0];
     },
     getFollowCount: async (channelID) => {
         const token = await getAppAccessToken();
-        const { total } = await request(`https://api.twitch.tv/helix/users/follows?to_id=${channelID}&first=1`, {
-            headers: createHeaderObject(token),
-            method: "GET",
-        });
+        const { total } = await request(
+            `https://api.twitch.tv/helix/users/follows?to_id=${channelID}&first=1`,
+            { headers: createHeaderObject(token) },
+            getNewAppAccessToken
+        );
         return total;
     },
     getSubCount: async (channelID) => {
         const token = await getTokenForChannel(channelID);
-        const { total } = await request(`https://api.twitch.tv/helix/subscriptions?broadcaster_id=${channelID}`, {
-            headers: createHeaderObject(token),
-            method: "GET",
-        });
+        const { total } = await request(
+            `https://api.twitch.tv/helix/subscriptions?broadcaster_id=${channelID}`,
+            { headers: createHeaderObject(token) },
+            getNewUserAuthToken
+        );
         return total;
     },
     getStreamData: async (loginName) => {
         const token = await getAppAccessToken();
-        const data = await request(`https://api.twitch.tv/helix/streams?user_login=${loginName}`, {
-            headers: createHeaderObject(token),
-            method: "GET",
-        });
-        return data.data[0];
+        const { data } = await request(
+            `https://api.twitch.tv/helix/streams?user_login=${loginName}`,
+            { headers: createHeaderObject(token) },
+            getNewAppAccessToken
+        );
+        return data[0];
     },
 };

--- a/External Data APIs/twitch.js
+++ b/External Data APIs/twitch.js
@@ -20,10 +20,12 @@ const createHeaderObject = (token) => {
 };
 
 const validateToken = async (token) => {
+    timedLog("validating app access token...");
     const res = await fetch("https://id.twitch.tv/oauth2/validate", {
         headers: createHeaderObject(token),
     });
     if (res.status === 401) {
+        timedLog("app access token not valid, refreshing...");
         await getNewAppAccessToken();
         resetValidationInterval();
     }
@@ -35,6 +37,7 @@ const getTokenForChannel = async (id) => {
 };
 
 const getNewUserAuthToken = async (id) => {
+    timedLog("fetching new user authentication token...");
     const { refresh_token: rt } = await DBService.getTokensForChannel(id);
     const res = await fetch(
         `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=refresh_token&refresh_token=${rt}`,
@@ -46,6 +49,7 @@ const getNewUserAuthToken = async (id) => {
 };
 
 const getNewAppAccessToken = async () => {
+    timedLog("fetching new app access token...");
     appAccessToken = undefined;
     const res = await fetch(
         `https://id.twitch.tv/oauth2/token?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&grant_type=client_credentials`,

--- a/External Data APIs/twitch.js
+++ b/External Data APIs/twitch.js
@@ -7,7 +7,7 @@ const { request, timedLog } = require("../utils");
 const fetch = require("node-fetch");
 const DBService = require("../dbservice");
 
-const { CLIENT_ID, CLIENT_SECRET } = process.env;
+const { CLIENT_ID, CLIENT_SECRET, BOT_USER_ID } = process.env;
 
 let appAccessToken;
 let validationInterval;
@@ -151,5 +151,13 @@ module.exports = {
             getNewAppAccessToken
         );
         return data[0];
+    },
+    setModeratorStatus: async (channelID, add) => {
+        const token = await getTokenForChannel(channelID);
+        await request(
+            `https://api.twitch.tv/helix/moderation/moderators?broadcaster_id=${channelID}&user_id=${BOT_USER_ID}`,
+            { method: add ? "POST" : "DELETE", headers: createHeaderObject(token) },
+            getNewUserAuthToken
+        );
     },
 };

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Mitchell Adair
+// Copyright (c) 2020-2022 Mitchell Adair
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -34,8 +34,8 @@ Array.prototype.chunk = function (maxChunkSize) {
 // ===================== EVENT HANDLERS =====================
 
 const onConnected = async (address, port) => {
-    timedLog(`** BOT: Connected to ${address}:${port}`);
-    timedLog(`** BOT: Joining all serviced channels...`);
+    timedLog(`Connected to ${address}:${port}`);
+    timedLog(`Joining all serviced channels...`);
     try {
         const channels = await DBService.getEnabledChannels();
         const channelData = await twitchAPI.getBatchUsersByID(channels);
@@ -51,9 +51,9 @@ const onConnected = async (address, port) => {
                 }, i * 15000);
             });
         }
-        timedLog(`** BOT: All channels joined`);
+        timedLog(`All channels joined`);
     } catch (err) {
-        timedLog(`** BOT: ERROR joining channels: ${err.message}`);
+        timedLog(`ERROR joining channels: ${err.message}`);
     }
 };
 
@@ -104,7 +104,7 @@ const onChat = async (channelKey, userstate, message, self) => {
             }
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -121,7 +121,7 @@ const onHost = async (channelKey, username, viewers, autohost) => {
                 client.say(channelKey, msg);
             }
         } catch (err) {
-            timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+            timedLog(`ERROR on channel ${channelName}: ${err.message}`);
         }
     }
 };
@@ -138,7 +138,7 @@ const onRaid = async (channelKey, username, viewers) => {
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -157,7 +157,7 @@ const onResub = async (channelKey, username, monthStreak, _message, userstate, m
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -177,7 +177,7 @@ const onSubGift = async (channelKey, username, monthStreak, recipient, methods, 
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -196,7 +196,7 @@ const onSubMysteryGift = async (channelKey, username, numbOfSubs, methods, users
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -212,7 +212,7 @@ const onSub = async (channelKey, username, methods, _message, _userstate) => {
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -226,7 +226,7 @@ const onAnonGiftUpgrade = async (channelKey, username, _userstate) => {
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -242,7 +242,7 @@ const onGiftUpgrade = async (channelKey, username, sender, _userstate) => {
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -258,7 +258,7 @@ const onCheer = async (channelKey, userstate, _message) => {
             client.say(channelKey, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${channelName}: ${err.message}`);
+        timedLog(`ERROR on channel ${channelName}: ${err.message}`);
     }
 };
 
@@ -271,7 +271,7 @@ const onFollow = async ({ broadcaster_user_login, user_name }) => {
             client.say(`#${broadcaster_user_login}`, msg);
         }
     } catch (err) {
-        timedLog(`** BOT: ERROR on channel ${broadcaster_user_login}: ${err.message}`);
+        timedLog(`ERROR on channel ${broadcaster_user_login}: ${err.message}`);
     }
 };
 
@@ -315,13 +315,13 @@ const actions = {
             const channel = await DBService.getChannel(channelID);
             if (channel && ChannelManager.getChannel(channel.name)) {
                 const { name } = channel;
-                timedLog(`** BOT: Refreshing data for channel ${name}...`);
+                timedLog(`Refreshing data for channel ${name}...`);
                 ChannelManager.deleteChannel(name);
                 await ChannelManager.fetchChannelData(name);
-                timedLog(`** BOT: Refreshed channel ${name}`);
+                timedLog(`Refreshed channel ${name}`);
             }
         } catch (err) {
-            timedLog(`** BOT: ERROR refreshing channel ${channelID}: ${err.message}`);
+            timedLog(`ERROR refreshing channel ${channelID}: ${err.message}`);
         }
     },
     joinChannel: async (channelID) => {
@@ -331,7 +331,7 @@ const actions = {
                 await client.join(data.name);
             }
         } catch (err) {
-            timedLog(`** BOT: ERROR joining channel ${channelID}: ${err.message}`);
+            timedLog(`ERROR joining channel ${channelID}: ${err.message}`);
         }
     },
     leaveChannel: async (channelID) => {
@@ -341,7 +341,7 @@ const actions = {
                 await client.part(data.name);
             }
         } catch (err) {
-            timedLog(`** BOT: ERROR leaving channel ${channelID}: ${err.message}`);
+            timedLog(`ERROR leaving channel ${channelID}: ${err.message}`);
         }
     },
     subscribeFollow: (channelID) => {

--- a/app.js
+++ b/app.js
@@ -326,22 +326,26 @@ const actions = {
     },
     joinChannel: async (channelID) => {
         try {
-            const data = await twitchAPI.getUser(channelID);
-            if (data) {
-                await client.join(data.name);
+            const { login } = await twitchAPI.getUser(channelID);
+            if (login) {
+                await client.join(login);
             }
         } catch (err) {
-            timedLog(`ERROR joining channel ${channelID}: ${err.message}`);
+            const { message } = err;
+            timedLog(`ERROR joining channel ${channelID}: ${message || err}`);
+            throw err;
         }
     },
     leaveChannel: async (channelID) => {
         try {
-            const data = await twitchAPI.getUser(channelID);
-            if (data) {
-                await client.part(data.name);
+            const { login } = await twitchAPI.getUser(channelID);
+            if (login) {
+                await client.part(login);
             }
         } catch (err) {
-            timedLog(`ERROR leaving channel ${channelID}: ${err.message}`);
+            const { message } = err;
+            timedLog(`ERROR leaving channel ${channelID}: ${message || err}`);
+            throw err;
         }
     },
     subscribeFollow: (channelID) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mthebot",
       "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
@@ -12,6 +13,7 @@
         "express": "4.17.1",
         "express-validator": "6.14.0",
         "mysql2": "2.3.3",
+        "node-fetch": "2.6.7",
         "nodemailer": "6.6.1",
         "tesjs": "0.6.0",
         "tmi.js": "1.8.5"
@@ -640,7 +642,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -689,12 +691,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -1216,7 +1218,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -1250,12 +1252,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "express": "4.17.1",
     "express-validator": "6.14.0",
     "mysql2": "2.3.3",
+    "node-fetch": "2.6.7",
     "nodemailer": "6.6.1",
     "tesjs": "0.6.0",
     "tmi.js": "1.8.5"

--- a/utils.js
+++ b/utils.js
@@ -19,6 +19,7 @@ module.exports = {
         const r = async () => {
             const res = await fetch(url, options);
             if (res.status === 401) {
+                timedLog("received 401 when attempting request, retrying with new token...");
                 const newToken = await onAuthFailure();
                 options.header.authorization = `Bearer ${newToken}`;
                 return r();

--- a/utils.js
+++ b/utils.js
@@ -19,6 +19,9 @@ module.exports = {
         const r = async () => {
             const res = await fetch(url, options);
             if (res.status === 401) {
+                if (!onAuthFailure) {
+                    throw new Error("received 401 error without a way to refresh");
+                }
                 timedLog("received 401 when attempting request, retrying with new token...");
                 const newToken = await onAuthFailure();
                 options.header.authorization = `Bearer ${newToken}`;

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-const https = require("https");
+const fetch = require("node-fetch");
 
 const USER_TYPES = {
     user: 0,
@@ -15,31 +15,14 @@ const USER_TYPES = {
 };
 
 module.exports = {
-    request: (url, options) => {
-        return new Promise((resolve, reject) => {
-            https
-                .request(url, options, (res) => {
-                    let data = [];
-                    res.on("error", (err) => {
-                        reject(err);
-                    })
-                        .on("data", (chunk) => {
-                            data.push(chunk);
-                        })
-                        .on("end", () => {
-                            data = JSON.parse(Buffer.concat(data).toString());
-                            if (data.error) {
-                                reject(data);
-                            } else {
-                                resolve(data);
-                            }
-                        });
-                })
-                .on("error", (err) => {
-                    reject(err);
-                })
-                .end();
-        });
+    request: async (url, options) => {
+        const res = await fetch(url, options);
+        const clone = res.clone(); // can only read res once, so clone so we can fallback to text
+        try {
+            return clone.json();
+        } catch {
+            return res.text();
+        }
     },
     getLengthDataFromMillis: (ms) => {
         const date = new Date(ms);

--- a/utils.js
+++ b/utils.js
@@ -61,6 +61,6 @@ module.exports = {
             : 0;
     },
     timedLog: (message) => {
-        console.log(`${new Date().toUTCString()} ${message}`);
+        console.log(`** BOT: ${new Date().toUTCString()} ${message}`);
     },
 };

--- a/utils.js
+++ b/utils.js
@@ -15,7 +15,7 @@ const USER_TYPES = {
 };
 
 module.exports = {
-    httpsRequest: (url, options) => {
+    request: (url, options) => {
         return new Promise((resolve, reject) => {
             https
                 .request(url, options, (res) => {


### PR DESCRIPTION
## Changes
- Switched to using `node-fetch` for requests
  - simplifies requests and makes it more robust
  - closes #86 
- Auto refresh auth tokens on request 401 responses
  - makes the request flow a little more streamlined
  - closes #87 
- Automatically add MtheBot_ as mod on enable, remove on disable
  - Required addition of new `BOT_USER_ID` environment variable
  - closes #84 
- Simplified `timedLog` by adding the `** BOT: ` part directly in the function

## Fixes
- Fixed bug in `joinChannel` and `leaveChannel` actions
  - was using `name` instead of `login` when passing to `part`/`join`
  - also throw on error of these so the API will send a 500 response in error cases from this