### PR TITLE
[fix] fix uat refresh, update DB env vars

### DIFF
--- a/External Data APIs/twitch.js
+++ b/External Data APIs/twitch.js
@@ -139,7 +139,7 @@ module.exports = {
         const { total } = await request(
             `https://api.twitch.tv/helix/subscriptions?broadcaster_id=${channelID}`,
             { headers: createHeaderObject(token) },
-            getNewUserAuthToken
+            () => getNewUserAuthToken(channelID)
         );
         return total;
     },
@@ -157,7 +157,7 @@ module.exports = {
         await request(
             `https://api.twitch.tv/helix/moderation/moderators?broadcaster_id=${channelID}&user_id=${BOT_USER_ID}`,
             { method: add ? "POST" : "DELETE", headers: createHeaderObject(token) },
-            getNewUserAuthToken
+            () => getNewUserAuthToken(channelID)
         );
     },
     getNewAppAccessToken,

--- a/dbservice.js
+++ b/dbservice.js
@@ -6,7 +6,7 @@
 const mysql = require("mysql2");
 const defaultEvents = require("./defaultEvents.json");
 
-const { RDS_HOSTNAME, RDS_USERNAME, RDS_PASSWORD, RDS_PORT, RDS_DB_NAME, CLIENT_SECRET } = process.env;
+const { DB_HOSTNAME, DB_USERNAME, DB_PASSWORD, DB_PORT, DB_NAME, CLIENT_SECRET } = process.env;
 
 class DBService {
     constructor() {
@@ -16,11 +16,12 @@ class DBService {
 
         this.db = mysql
             .createPool({
-                host: RDS_HOSTNAME,
-                user: RDS_USERNAME,
-                password: RDS_PASSWORD,
-                port: RDS_PORT,
-                database: RDS_DB_NAME,
+                host: DB_HOSTNAME,
+                port: DB_PORT,
+                user: DB_USERNAME,
+                password: DB_PASSWORD,
+                database: DB_NAME,
+                ssl: { rejectUnauthorized: true },
             })
             .promise();
 


### PR DESCRIPTION
## Changes
- update env vars to be more generic for the DB
  - enables the switch over to PlanetScale as the primary DB provider for prod

## Fixes
- fixes a bug in user access token refresh where the channel id was not being passed into the refresh function, causing a DB error/crash